### PR TITLE
Not Audio features, improved code structure, slightly cleaner rate limit implementation (imo), extra uris and ids

### DIFF
--- a/exportify-cli.py
+++ b/exportify-cli.py
@@ -143,7 +143,7 @@ Copy the Client ID, Client Secret and Redirect URI and paste them below.
         self._write_tracks_to_csv(tracks, file_path, playlist["name"])
 
     def _spotify_data_to_nice_dict(
-        self, playlist_item: Dict, track_data: Dict, album_data: List[Dict]
+        self, playlist_item: Dict, track_data: Dict, album_data: Dict
     ) -> Dict:
         """Convert Spotify data to a more readable dictionary."""
         artist_data = track_data.get("artists", [])
@@ -166,7 +166,7 @@ Copy the Client ID, Client Secret and Redirect URI and paste them below.
             "Track ISRC": track_data.get("external_ids", {}).get("isrc", ""),
             "Album UPC": album_data.get("external_ids", {}).get("upc", ""),
         }
-        
+
         if not self.include_uris:
             track.pop("Artist URI(s)")
             track.pop("Album URI")
@@ -231,8 +231,8 @@ Copy the Client ID, Client Secret and Redirect URI and paste them below.
             sliced_album_ids = [
                 album_ids[i : i + 20] for i in range(0, len(album_ids), 20)
             ]
-            for slice in sliced_album_ids:
-                album_results = self.spotify.albums(slice)
+            for albums_batch in sliced_album_ids:
+                album_results = self.spotify.albums(albums_batch)
                 playlist_items_albums.extend(album_results["albums"])
                 pbar.update(len(album_results["albums"]))
         return playlist_items_albums

--- a/exportify-cli.py
+++ b/exportify-cli.py
@@ -45,8 +45,15 @@ class RateLimitedSpotify:
 
 
 class SpotifyExporter:
-    def __init__(self, config_path: str = "config.cfg"):
+    def __init__(
+        self,
+        config_path: str = "config.cfg",
+        include_ids: bool = False,
+        external_ids: bool = False,
+    ):
         self.config = self._load_config(config_path)
+        self.include_ids = include_ids
+        self.external_ids = external_ids
         self.spotify = self._init_spotify_client()
 
     def _load_config(self, config_path: str) -> configparser.ConfigParser:
@@ -185,20 +192,9 @@ Copy the Client ID, Client Secret and Redirect URI and paste them below.
             "Popularity": lambda track: self._safe_get(track, "popularity"),
             "Added By": lambda item: self._safe_get(item, "added_by", "id"),
             "Added At": lambda item: self._safe_get(item, "added_at"),
-            "Genres": lambda: "",
-            "Record Label": lambda: "",
-            "Danceability": lambda: "",
-            "Energy": lambda: "",
-            "Key": lambda: "",
-            "Loudness": lambda: "",
-            "Mode": lambda: "",
-            "Speechiness": lambda: "",
-            "Acousticness": lambda: "",
-            "Instrumentalness": lambda: "",
-            "Liveness": lambda: "",
-            "Valence": lambda: "",
-            "Tempo": lambda: "",
-            "Time Signature": lambda: "",
+            "ISRC": lambda track: self._safe_get(track, "external_ids", "isrc"),
+            "EAN": lambda track: self._safe_get(track, "external_ids", "ean"),
+            "UPC": lambda track: self._safe_get(track, "external_ids", "upc"),
         }
 
         headers = fields.keys()
@@ -256,14 +252,22 @@ def main():
     parser.add_argument("-l", "--list", action="store_true", help="List all playlists")
     parser.add_argument(
         "-i",
-        "--id",
+        "--include-ids",
         action="store_true",
         help="Include albums and artist(s) IDs in the exported fields",
+    )
+    parser.add_argument(
+        "-e",
+        "--external-ids",
+        action="store_true",
+        help="Include track ISRC, EAN and UPC in the exported fields",
     )
 
     args = parser.parse_args()
 
-    exporter = SpotifyExporter()
+    exporter = SpotifyExporter(
+        include_ids=args.include_ids, external_ids=args.external_ids
+    )
 
     # Initialize Spotify connection
     exporter.spotify.current_user()

--- a/uv.lock
+++ b/uv.lock
@@ -13,11 +13,11 @@ wheels = [
 
 [[package]]
 name = "certifi"
-version = "2025.1.31"
+version = "2025.4.26"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/1c/ab/c9f1e32b7b1bf505bf26f0ef697775960db7932abeb7b516de930ba2705f/certifi-2025.1.31.tar.gz", hash = "sha256:3d5da6925056f6f18f119200434a4780a94263f10d1c21d032a6f6b2baa20651", size = 167577, upload_time = "2025-01-31T02:16:47.166Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e8/9e/c05b3920a3b7d20d3d3310465f50348e5b3694f4f88c6daf736eef3024c4/certifi-2025.4.26.tar.gz", hash = "sha256:0a816057ea3cdefcef70270d2c515e4506bbc954f417fa5ade2021213bb8f0c6", size = 160705, upload_time = "2025-04-26T02:12:29.51Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/38/fc/bce832fd4fd99766c04d1ee0eead6b0ec6486fb100ae5e74c1d91292b982/certifi-2025.1.31-py3-none-any.whl", hash = "sha256:ca78db4565a652026a4db2bcdf68f2fb589ea80d0be70e03929ed730746b84fe", size = 166393, upload_time = "2025-01-31T02:16:45.015Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/7e/3db2bd1b1f9e95f7cddca6d6e75e2f2bd9f51b1246e546d88addca0106bd/certifi-2025.4.26-py3-none-any.whl", hash = "sha256:30350364dfe371162649852c63336a15c70c6510c2ad5015b21c2345311805f3", size = 159618, upload_time = "2025-04-26T02:12:27.662Z" },
 ]
 
 [[package]]
@@ -106,15 +106,25 @@ wheels = [
 ]
 
 [[package]]
+name = "pyjwt"
+version = "2.9.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fb/68/ce067f09fca4abeca8771fe667d89cc347d1e99da3e093112ac329c6020e/pyjwt-2.9.0.tar.gz", hash = "sha256:7e1e5b56cc735432a7369cbfa0efe50fa113ebecdc04ae6922deba8b84582d0c", size = 78825, upload_time = "2024-08-01T15:01:08.445Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/79/84/0fdf9b18ba31d69877bd39c9cd6052b47f3761e9910c15de788e519f079f/PyJWT-2.9.0-py3-none-any.whl", hash = "sha256:3b02fb0f44517787776cf48f2ae25d8e14f300e6d7545a4315cee571a415e850", size = 22344, upload_time = "2024-08-01T15:01:06.481Z" },
+]
+
+[[package]]
 name = "redis"
-version = "5.2.1"
+version = "5.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "async-timeout", marker = "python_full_version < '3.11.3'" },
+    { name = "pyjwt" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/47/da/d283a37303a995cd36f8b92db85135153dc4f7a8e4441aa827721b442cfb/redis-5.2.1.tar.gz", hash = "sha256:16f2e22dff21d5125e8481515e386711a34cbec50f0e44413dd7d9c060a54e0f", size = 4608355, upload_time = "2024-12-06T09:50:41.956Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/71/dd/2b37032f4119dff2a2f9bbcaade03221b100ba26051bb96e275de3e5db7a/redis-5.3.0.tar.gz", hash = "sha256:8d69d2dde11a12dc85d0dbf5c45577a5af048e2456f7077d87ad35c1c81c310e", size = 4626288, upload_time = "2025-04-30T14:54:40.634Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3c/5f/fa26b9b2672cbe30e07d9a5bdf39cf16e3b80b42916757c5f92bca88e4ba/redis-5.2.1-py3-none-any.whl", hash = "sha256:ee7e1056b9aea0f04c6c2ed59452947f34c4940ee025f5dd83e6a6418b6989e4", size = 261502, upload_time = "2024-12-06T09:50:39.656Z" },
+    { url = "https://files.pythonhosted.org/packages/45/b0/aa601efe12180ba492b02e270554877e68467e66bda5d73e51eaa8ecc78a/redis-5.3.0-py3-none-any.whl", hash = "sha256:f1deeca1ea2ef25c1e4e46b07f4ea1275140526b1feea4c6459c0ec27a10ef83", size = 272836, upload_time = "2025-04-30T14:54:30.744Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
I wanted to add audio features (like Danceability, Energy, Genres, etc) for each track but Spotify deprecated those in the api last year (https://developer.spotify.com/blog/2024-11-27-changes-to-the-web-api).

Instead I did these:
- Introduce a `rate_limited` decorator and `RateLimitedSpotify` wrapper to automatically retry on HTTP 429s
- Added Record label field to the export
- Split playlist export into three clear steps:
  1. `_fetch_playlist_items`
  2. `_fetch_album_details` (although only `label` is added from these)
  3. `_spotify_data_to_nice_dict` (to normalize API payload into export-ready dict)
- Simplify CSV writing: infer headers from first track, write rows directly
- Added flags `--include-uris` to optionally add album and artist URIs and `--external-ids` to add track ISRC and album UPC
